### PR TITLE
Updating Depot endpoints for US, EU and KR.

### DIFF
--- a/src-app/hu/scelight/sc2/rep/model/initdata/gamedesc/Region.java
+++ b/src-app/hu/scelight/sc2/rep/model/initdata/gamedesc/Region.java
@@ -33,15 +33,15 @@ import java.util.Set;
 public enum Region implements IRegion {
 	
 	/** US */
-	US( "US", "US", 1, Icons.C_UNITED_STATES, "http://us.depot.battle.net:1119/", "http://us.battle.net/", BnetLang.ENGLISH, EnumSet.of( BnetLang.ENGLISH,
+	US( "US", "US", 1, Icons.C_UNITED_STATES, "https://us-s2-depot.classic.blizzard.com/", "http://us.battle.net/", BnetLang.ENGLISH, EnumSet.of( BnetLang.ENGLISH,
 	        BnetLang.SPANISH, BnetLang.PORTUGUESE ), Realm.NORTH_AMERICA, Realm.LATIN_AMERICA ),
 	
 	/** Europe */
-	EUROPE( "Europe", "EU", 2, Icons.C_EUROPE, "http://eu.depot.battle.net:1119/", "http://eu.battle.net/", BnetLang.ENGLISH, EnumSet.of( BnetLang.ENGLISH,
+	EUROPE( "Europe", "EU", 2, Icons.C_EUROPE, "https://eu-s2-depot.classic.blizzard.com/", "http://eu.battle.net/", BnetLang.ENGLISH, EnumSet.of( BnetLang.ENGLISH,
 	        BnetLang.GERMAN, BnetLang.FRENCH, BnetLang.SPANISH, BnetLang.RUSSIAN, BnetLang.ITALIAN, BnetLang.POLISH ), Realm.EUROPE, Realm.RUSSIA ),
 	
 	/** Korea */
-	KOREA( "Korea", "KR", 3, Icons.C_KOREA, "http://kr.depot.battle.net:1119/", "http://kr.battle.net/", BnetLang.KOREAN, EnumSet.of( BnetLang.KOREAN,
+	KOREA( "Korea", "KR", 3, Icons.C_KOREA, "https://kr-s2-depot.classic.blizzard.com/", "http://kr.battle.net/", BnetLang.KOREAN, EnumSet.of( BnetLang.KOREAN,
 	        BnetLang.CHINESE_TRADITIONAL ), Realm.KOREA, Realm.TAIWAN ),
 	
 	/** China */


### PR DESCRIPTION
The US, EU and KR regions have newer endpoints for Depot, now supporting TLSv1.